### PR TITLE
incorrect URL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deploy DC/OS using Terraform
+# Deploy Open DC/OS using Terraform
 
 The purpose of this tool is to automate most of the manual efforts of managing and maintaining distributed systems. This project has a few important goals in mind since the inception of the project.
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,4 +1,4 @@
-# DC/OS on AWS with Terraform
+# Open DC/OS on AWS with Terraform
 
 ## Getting Started
 
@@ -12,25 +12,36 @@ brew install terraform
 
 If you want to leverage the terraform installer, feel free to check out https://www.terraform.io/downloads.html.
 
-#### Configure your Cloud Provider Credentials
+### Configure your Cloud Provider Credentials
 
-##### AWS
+**Configure your AWS ssh Keys**
 
-You can use an AWS credentials file to specify your credentials. The default location is `$HOME/.aws/credentials` on Linux and OS X, or `"%USERPROFILE%\.aws\credentials"` for Windows users.
-
-**Configure your AWS Keys**
-
-In the `variable.tf` there is a `key_name` variable. This key must be added to your host machine running your terraform script as it will be used to log into the machines to run setup scripts. The default is `default`. You can find aws documentation that talks about this [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws)
+In the `variable.tf` there is a `key_name` variable. This key must be added to your host machine running your terraform script as it will be used to log into the machines to run setup scripts. The default is `default`. You can find aws documentation that talks about this [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws).
 
 When you have your key available, you can use ssh-add.
 
 ```bash
 ssh-add ~/.ssh/path_to_you_key.pem
 ```
+**Configure your IAM AWS Keys**
+
+You will need your AWS aws_access_key_id and aws_secret_access_key. If you dont have one yet, you can get them from the AWS documetnation [here](
+http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html). When you finally get them, you can install it in your home directory. The default location is `$HOME/.aws/credentials` on Linux and OS X, or `"%USERPROFILE%\.aws\credentials"` for Windows users.
+
+Here is an example of the output when you're done:
+
+```bash
+$ cat ~/.aws/credentials
+[default]
+aws_access_key_id = ACHEHS71DG712w7EXAMPLE
+aws_secret_access_key = /R8SHF+SHFJaerSKE83awf4ASyrF83sa471DHSEXAMPLE
+```
+
+### Example Terraform Deployments
 
 **Pull down the DC/OS terraform scripts below**
 
-There is a module called `dcos-tested-aws-oses` that contains all the tested scripts per operating system. The deployment strategy is a base AMI coupled with a prereq `script.sh` to get it ready to install dcos-core components. Its simple to add other operating systems by adding the ami, region, and install scripts to meet the dcos specifications that can be found [here](https://dcos.io/docs/1.9/administration/installing/custom/system-requirements/) and [here](https://dcos.io/docs/1.9/administration/installing/custom/system-requirements/install-docker-centos/) as an example.
+There is a module called `dcos-tested-aws-oses` that contains all the tested scripts per operating system. The deployment strategy is a base AMI coupled with a prereq `script.sh` to get it ready to install dcos-core components. Its simple to add other operating systems by adding the ami, region, and install scripts to meet the dcos specifications that can be found [here](https://dcos.io/docs/1.9/installing/custom/system-requirements/) and [here](https://dcos.io/docs/1.9/installing/custom/system-requirements/install-docker-centos/) as an example.
 
 
 For CoreOS 1235.9.0:
@@ -43,7 +54,7 @@ For CoreOS 835.13.0:
 
 ```bash
 terraform init github.com/bernadinm/terraform-dcos/aws
-terraform plan --var os=coreos_835.13.0 --var dcos_overlay_enable=disable # This OS cannot support docker networking
+terraform plan --var os=coreos_835.13.0
 ```
 
 For Centos 7.2:
@@ -52,8 +63,6 @@ For Centos 7.2:
 terraform init github.com/bernadinm/terraform-dcos/aws
 terraform plan --var os=centos_7.2
 ```
-
-Once `terraform plan` completes successfully you can deploy it by simply doing replacing `plan` with `apply`. Read more for more information.
 
 ## Pro-tip: Use Terraform’s -var-file
 
@@ -104,6 +113,28 @@ terraform apply -var dcos_version=1.9.0
 terraform apply
 ```
 
+### Config.yaml Modification
+
+You can modify all the DC/OS config.yaml flags via terraform. Here is an example of using the master_http_loadbalancer for cloud deployments. **master_http_loadbalancer is recommended for production**. You will be able to replace your masters in a multi master environment. Using the default static backend will not give you this option. 
+
+Here is an example default profile that will allow you to do this. 
+
+```bash
+$ cat desired_cluster_profile
+num_of_masters = "3"
+num_of_private_agents = "2"
+num_of_public_agents = "1"
+dcos_security = "permissive"
+dcos_version = "1.8.8"
+dcos_aws_access_key_id = "ACHEHS71DG712w7EXAMPLE"
+dcos_aws_secret_access_key = "/R8SHF+SHFJaerSKE83awf4ASyrF83sa471DHSEXAMPLE"
+dcos_master_discovery = "master_http_loadbalancer"
+dcos_exhibitor_storage_backend = "aws_s3"
+dcos_exhibitor_explicit_keys = "true"
+```
+
+**NOTE:** This will append your aws_access_key_id and aws_secret_access_key key in your config.yaml on your bootstrap node so DC/OS will know how to upload its state to the aws_s3 bucket. 
+
 ## Upgrading DC/OS  
 
 You can upgrade your DC/OS cluster with a single command. This terraform script was built to perform installs and upgrade from the inception of this project. With the upgrade procedures below, you can also have finer control on how masters or agents upgrade at a given time. This will give you the ability to change the parallelism of master or agent upgrades.
@@ -122,18 +153,28 @@ If you take this route, you can use a few more commands but this will allow you 
 
 **Master upgrade sequentially one at a time**
 ```bash
-terraform apply --var os=coreos_1235.9.0 --var dcos_version=1.8.8  --var state=upgrade --var dcos_security=disabled -parallelism=1 -target=null_resource.master
+terraform apply \
+--var os=coreos_1235.9.0 \
+--var dcos_version=1.8.8 \
+--var state=upgrade \
+--var dcos_security=disabled \
+-parallelism=1 \
+-target=null_resource.master
  ```
 
 **Upgrade everything else in parallel**
  ```bash
-terraform apply --var os=coreos_1235.9.0 --var dcos_version=1.8.8  --var state=upgrade --var dcos_security=disabled
+terraform apply \
+--var os=coreos_1235.9.0 \
+--var dcos_version=1.8.8 \
+--var state=upgrade \
+--var dcos_security=disabled
   ```
   
   *NOTE: the default for parallelism is 10. You can change this value to control how many nodes you want upgraded at any given time*
 
 
-  ### DC/OS 1.8 Security Changes
+  ### Upgrading with DC/OS 1.8 Security Changes
 
   **Important**: DC/OS will is not designed to upgrade directly from disabled to strict. Please be responsible when using automation tools.
 
@@ -142,7 +183,10 @@ terraform apply --var os=coreos_1235.9.0 --var dcos_version=1.8.8  --var state=u
   On DC/OS 1.8 clusters, testing shows that you can actually upgrade the masters simultaneously from DC/OS 1.8 and 1.9, (not 1.7). So going forward, we can drop the `--parallelism=1` entirely. If this changes on a new version, I will be sure to call this out. To go from DC/OS 1.8 Disbaled to DC/OS 1.8 Permissive, you can upgrade by running this command below. Notice the `state` is still upgrade, because we're still doing an inplace upgrade to the same version. This allows you to make DC/OS cluster-wide changes on your cluster.
 
   ```bash
-  terraform apply --var dcos_version=1.8.8 --var state=upgrade --var dcos_security=permissive
+  terraform apply \
+  --var dcos_version=1.8.8 \
+  --var state=upgrade \
+  --var dcos_security=permissive
   ```
 
   #### Upgrading DC/OS 1.8 Permissive to DC/OS 1.8 Strict
@@ -150,7 +194,10 @@ terraform apply --var os=coreos_1235.9.0 --var dcos_version=1.8.8  --var state=u
   This command below will upgrade you from DC/OS permissive to DC/OS strict mode
 
   ```bash
-  terraform apply --var dcos_version=1.8.8 --var state=upgrade --var dcos_security=strict
+  terraform apply \
+  --var dcos_version=1.8.8 \
+  --var state=upgrade \
+  --var dcos_security=strict
   ```
 
   ### DC/OS 1.9 Upgrades
@@ -160,19 +207,28 @@ terraform apply --var os=coreos_1235.9.0 --var dcos_version=1.8.8  --var state=u
   #### Upgrading DC/OS 1.8 Disabled to DC/OS 1.9 Disabled
 
   ```bash
-  terraform apply --var dcos_version=1.9.0 --var state=upgrade --var dcos_security=disabled
+  terraform apply \
+  --var dcos_version=1.9.0 \
+  --var state=upgrade \
+  --var dcos_security=disabled
   ```
 
   #### Upgrading DC/OS 1.8 Permissive to DC/OS 1.9 Permissive
 
   ```bash
-  terraform apply --var dcos_version=1.9.0 --var state=upgrade --var dcos_security=permissive
+  terraform apply \
+  --var dcos_version=1.9.0 \
+  --var state=upgrade \
+  --var dcos_security=permissive
   ```
 
   #### Upgrading DC/OS 1.8 Strict to DC/OS 1.9 Strict
 
   ```bash
-  terraform apply --var dcos_version=1.9.0 --var state=upgrade --var dcos_security=strict
+  terraform apply \
+  --var dcos_version=1.9.0 \
+  --var state=upgrade \
+  --var dcos_security=strict
   ```
 
 ## Maintenance
@@ -182,13 +238,19 @@ If you would like to add more or remove (private) agents or public agents from y
 ### Adding Agents
 
 ```bash
-terraform apply -var-file desired_cluster_profile --var num_of_private_agents=5 --var num_of_public_agents=3
+terraform apply \
+-var-file desired_cluster_profile \
+--var num_of_private_agents=5 \
+--var num_of_public_agents=3
 ```
 
 ### Removing Agents
 
 ```bash
-terraform apply -var-file desired_cluster_profile --var num_of_private_agents=1 --var num_of_public_agents=1
+terraform apply \
+-var-file desired_cluster_profile \
+--var num_of_private_agents=1 \
+--var num_of_public_agents=1
 ```
 
 **Important**: Always remember to save your desired state in your `desired_cluster_profile`
@@ -204,6 +266,7 @@ If you wanted to redeploy a problematic agent, (ie. storage filled up, not respo
 
 ```bash
 terraform taint aws_instance.agent.0 # The number represents the agent in the list 
+terraform taint null_resource.agent.0 # The number represents the agent in the list 
 ```
 
 **Redeploy Agent**
@@ -219,6 +282,7 @@ terraform apply -var-file desired_cluster_profile
 
 ```bash
 terraform taint aws_instance.public-agent.0 # The number represents the agent in the list 
+terraform taint null_resource.public-agent.0 # The number represents the agent in the list 
 ```
 
 **Redeploy Agent**
@@ -227,7 +291,13 @@ terraform taint aws_instance.public-agent.0 # The number represents the agent in
 terraform apply -var-file desired_cluster_profile
 ```
 
+### Destroy Cluster
 
+You can shutdown/destroy all resources from your environment by running this command below
+
+```bash
+terraform destroy
+```
 
   # Roadmaps
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -464,7 +464,7 @@ resource "aws_instance" "master" {
   }
 
   count = "${var.num_of_masters}"
-  instance_type = "${var.aws_instance_type}"
+  instance_type = "${var.aws_master_instance_type}"
 
   tags {
    owner = "${coalesce(var.owner, data.external.whoami.result["owner"])}"
@@ -524,7 +524,7 @@ resource "aws_instance" "agent" {
   }
 
   count = "${var.num_of_private_agents}"
-  instance_type = "${var.aws_instance_type}"
+  instance_type = "${var.aws_agent_instance_type}"
 
   tags {
    owner = "${coalesce(var.owner, data.external.whoami.result["owner"])}"
@@ -583,7 +583,7 @@ resource "aws_instance" "public-agent" {
   }
 
   count = "${var.num_of_public_agents}"
-  instance_type = "${var.aws_instance_type}"
+  instance_type = "${var.aws_public_agent_instance_type}"
 
   tags {
    owner = "${coalesce(var.owner, data.external.whoami.result["owner"])}"
@@ -642,7 +642,7 @@ resource "aws_instance" "bootstrap" {
     volume_size = "${var.instance_disk_size}"
   }
 
-  instance_type = "${var.aws_instance_type}"
+  instance_type = "${var.aws_bootstrap_instance_type}"
 
   tags {
    owner = "${coalesce(var.owner, data.external.whoami.result["owner"])}"

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -751,7 +751,6 @@ resource "aws_instance" "bootstrap" {
     dcos_overlay_enable = "${var.dcos_overlay_enable}"
     dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
     dcos_overlay_network = "${var.dcos_overlay_network}"
-    dcos_overlays = "${var.dcos_overlays}"
     dcos_process_timeout = "${var.dcos_process_timeout}"
     dcos_agent_list = "\n - ${join("\n - ", aws_instance.agent.*.private_ip)}"
     # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
@@ -766,11 +765,13 @@ resource "aws_instance" "bootstrap" {
     dcos_superuser_username = "${var.dcos_superuser_username}"
     dcos_telemetry_enabled = "${var.dcos_telemetry_enabled}"
     dcos_use_proxy = "${var.dcos_use_proxy}"
-    dcos_vtep_mac_oui = "${var.dcos_vtep_mac_oui}"
-    dcos_vtep_subnet = "${var.dcos_vtep_subnet}"
     dcos_zk_agent_credentials = "${var.dcos_zk_agent_credentials}"
     dcos_zk_master_credentials = "${var.dcos_zk_master_credentials}"
     dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"    
+    dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
+    dcos_rexray_config = "${var.dcos_rexray_config}"
+    dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"
+    dcos_cluster_docker_registry_enabled = "${var.dcos_cluster_docker_registry_enabled}"
  }
 
 resource "null_resource" "bootstrap" {
@@ -842,6 +843,8 @@ resource "null_resource" "bootstrap" {
     dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"
     dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
     dcos_rexray_config = "${var.dcos_rexray_config}"
+    dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"
+    dcos_cluster_docker_registry_enabled = "${var.dcos_cluster_docker_registry_enabled}"
   }
 
   # Bootstrap script can run on any instance of the cluster

--- a/aws/modules/dcos-core/dcos-versions/1.7-open/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7-open/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7-open/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7-open/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.1/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.1/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.2/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.2/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.3/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.3/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.4/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.4/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.1/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.1/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.2/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.2/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.3/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.3/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.4/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.4/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.5/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.5/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.6/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.6/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.7/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.7/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.8/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.8/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 

--- a/aws/modules/dcos-core/dcos-versions/1.9.0/dcos-bootstrap/templates/install/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0/dcos-bootstrap/templates/install/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh

--- a/aws/modules/dcos-core/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/aws/modules/dcos-core/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -25,13 +25,13 @@ ${dcos_aws_access_key_id== "" ? "" : "aws_access_key_id: ${dcos_aws_access_key_i
 ${dcos_aws_region== "" ? "" : "aws_region: ${dcos_aws_region}"}
 ${dcos_aws_secret_access_key== "" ? "" : "aws_secret_access_key: ${dcos_aws_secret_access_key}"}
 ${dcos_exhibitor_explicit_keys== "" ? "" : "exhibitor_explicit_keys: ${dcos_exhibitor_explicit_keys}"}
-${dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}"}
-${dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}"}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_bucket== "" ? "" : "s3_bucket: ${dcos_s3_bucket}" : ""}
+${dcos_exhibitor_storage_backend == "aws_s3" ? dcos_s3_prefix== "" ? "" : "s3_prefix: ${dcos_s3_prefix}" : ""}
 ${dcos_exhibitor_azure_account_name== "" ? "" : "exhibitor_azure_account_name: ${dcos_exhibitor_azure_account_name}"}
 ${dcos_exhibitor_azure_account_key== "" ? "" : "exhibitor_azure_account_key: ${dcos_exhibitor_azure_account_key}"}
 ${dcos_exhibitor_azure_prefix== "" ? "" : "exhibitor_azure_prefix: ${dcos_exhibitor_azure_prefix}"}
-${dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}"}
 ${dcos_master_discovery == "master_http_loadbalancer" ? dcos_num_masters == "" ? "" : "num_masters: ${dcos_num_masters}" : ""}
+${dcos_master_discovery == "master_http_loadbalancer" ? dcos_exhibitor_address== "" ? "" : "exhibitor_address: ${dcos_exhibitor_address}" : ""}
 ${dcos_master_discovery == "static" ? dcos_master_list== "" ? "" : "master_list: ${dcos_master_list}" : ""}
 ${dcos_customer_key== "" ? "" : "customer_key: ${dcos_customer_key}"}
 ${dcos_rexray_config_method== "" ? "" : "rexray_config_method: ${dcos_rexray_config_method}"}
@@ -68,6 +68,9 @@ ${dcos_cluster_docker_credentials_enabled== "" ? "" : "cluster_docker_credential
 ${dcos_cluster_docker_registry_url == "" ? "" : "cluster_docker_registry_url: ${dcos_cluster_docker_registry_url}"}
 ${dcos_cluster_docker_registry_enabled == "" ? "" : "cluster_docker_registry_enabled: ${dcos_cluster_docker_registry_enabled}"}
 ${dcos_rexray_config == "" ? "" : "rexray_config: ${dcos_rexray_config}"}
+${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? "" : "cosmos_config:"}
+${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
+${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ''' | sed '/^$/d' | sudo tee genconf/config.yaml
 sudo cp /tmp/ip-detect genconf/.
 sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 

--- a/aws/modules/dcos-core/download-variables.tf
+++ b/aws/modules/dcos-core/download-variables.tf
@@ -11,7 +11,7 @@ variable "dcos_download_path" {
    "1.8.5"      = "https://downloads.dcos.io/dcos/stable/commit/e665123df0dbb19adacaefe47d16a3de144d5733/dcos_generate_config.sh"
    "1.8.6"      = "https://downloads.dcos.io/dcos/stable/commit/cfccfbf84bbba30e695ae4887b65db44ff216b1d/dcos_generate_config.sh"
    "1.8.7"      = "https://downloads.dcos.io/dcos/stable/commit/1b43ff7a0b9124db9439299b789f2e2dc3cc086c/dcos_generate_config.sh"
-   "1.8.8"      = "https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh"
+   "1.8.8"      = "https://downloads.dcos.io/dcos/stable/commit/602edc1b4da9364297d166d4857fc8ed7b0b65ca/dcos_generate_config.sh"
    "1.9.0-rc1"  = "https://downloads.dcos.io/dcos/EarlyAccess/commit/26d16366a29aba258541a8653b00522c4c1c21fc/dcos_generate_config.sh"
    "1.9.0-rc2"  = "https://downloads.dcos.io/dcos/EarlyAccess/commit/7f1ce42734aa54053291f403d71e3cb378bd13f3/dcos_generate_config.sh"
    "1.9.0-rc3"  = "https://downloads.dcos.io/dcos/EarlyAccess/commit/e5b5e6e336763ba9c8ed2d8266c798873e501cb2/dcos_generate_config.sh"

--- a/aws/modules/dcos-core/main.tf
+++ b/aws/modules/dcos-core/main.tf
@@ -71,6 +71,9 @@ template = "${file("${path.module}/dcos-versions/${var.dcos_version}/${var.role}
     dcos_rexray_config = "${var.dcos_rexray_config}"
     dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"    
     dcos_cluster_docker_registry_enabled = "${var.dcos_cluster_docker_registry_enabled}"
+    dcos_enable_docker_gc = "${var.dcos_enable_docker_gc}"
+    dcos_staged_package_storage_uri = "${var.dcos_staged_package_storage_uri}"
+    dcos_package_storage_uri = "${var.dcos_package_storage_uri}"
   }
 }
 

--- a/aws/modules/dcos-core/main.tf
+++ b/aws/modules/dcos-core/main.tf
@@ -69,6 +69,8 @@ template = "${file("${path.module}/dcos-versions/${var.dcos_version}/${var.role}
     dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"
     dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
     dcos_rexray_config = "${var.dcos_rexray_config}"
+    dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"    
+    dcos_cluster_docker_registry_enabled = "${var.dcos_cluster_docker_registry_enabled}"
   }
 }
 

--- a/aws/modules/dcos-core/variables.tf
+++ b/aws/modules/dcos-core/variables.tf
@@ -279,3 +279,7 @@ variable "dcos_cluster_docker_registry_url" {
 variable "custom_dcos_download_path" {
    default = ""
 }
+
+variable "dcos_cluster_docker_registry_enabled" {
+  default = ""
+}

--- a/aws/modules/dcos-core/variables.tf
+++ b/aws/modules/dcos-core/variables.tf
@@ -283,3 +283,15 @@ variable "custom_dcos_download_path" {
 variable "dcos_cluster_docker_registry_enabled" {
   default = ""
 }
+
+variable "dcos_enable_docker_gc" {
+ default = ""
+}
+
+variable "dcos_staged_package_storage_uri" {
+ default = ""
+}
+
+variable "dcos_package_storage_uri" {
+ default = ""
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -2,6 +2,10 @@ output "Master ELB Address" {
   value = "${aws_elb.public-master-elb.dns_name}"
 }
 
+output "Public Agent ELB Address" {
+  value = "${aws_elb.public-agent-elb.dns_name}"
+}
+
 output "Mesos Master Public IP" {
   value = ["${aws_instance.master.*.public_ip}"]
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -13,3 +13,7 @@ output "Private Agent Public IP Address" {
 output "Public Agent Public IP Address" {
   value = ["${aws_instance.public-agent.*.public_ip}"]
 }
+
+output "Bootstrap Public IP Address" {
+  value = "${aws_instance.bootstrap.public_ip}"
+}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -18,9 +18,24 @@ variable "os" {
   description = "Recommended DC/OS OSs are centos_7.2, coreos_1235.9.0, coreos_835.13.0"
 }
 
-variable "aws_instance_type" {
-  description = "AWS default instance type"
+variable "aws_master_instance_type" {
+  description = "AWS DC/OS master instance type"
   default = "m3.xlarge"
+}
+
+variable "aws_agent_instance_type" {
+  description = "AWS DC/OS Private Agent instance type"
+  default = "m3.xlarge"
+}
+
+variable "aws_public_agent_instance_type" {
+  description = "AWS DC/OS Public instance type"
+  default = "m3.xlarge"
+}
+
+variable "aws_bootstrap_instance_type" {
+  description = "AWS DC/OS Bootstrap instance type"
+  default = "m3.large"
 }
 
 variable "num_of_private_agents" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -403,6 +403,11 @@ variable "state" {
  description = "Support installing or Upgrading DC/OS"
 }
 
+variable "dcos_ip_detect_public_contents" {
+ default = "\"\\x27#!/bin/sh\\\\n\\\\n  set -o nounset -o errexit\\\\n\\\\n\\\\n  curl -fsSL http://169.254.169.254/latest/meta-data/public-ipv4\\\\n\\\\n   \\x27\\\\n\""
+ description = "Used for AWS to determine the public IP. Note: single quotes was subsututed for hex x27 as it cannot be used. Currently escapes will need to be performed twice. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
+}
+
 # Core OS
 variable "aws_amis" {
   default = {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -405,6 +405,21 @@ variable "dcos_cluster_docker_registry_url" {
  description = "This parameter specifies a custom URL that Mesos uses to pull Docker images from. If set, it will configure the Mesos’ --docker_registry flag to the specified URL. This changes the default URL Mesos uses for pulling Docker images. By default https://registry-1.docker.io is used."
 }
 
+variable "dcos_enable_docker_gc" {
+ default = ""
+ description = "This parameter specifies whether to run the docker-gc script, a simple Docker container and image garbage collection script, once every hour to clean up stray Docker containers. You can configure the runtime behavior by using the /etc/ config. For more information, see the documentation"
+}
+
+variable "dcos_staged_package_storage_uri" {
+ default = ""
+ description = "This parameter specifies where to temporarily store DC/OS packages while they are being added. The value must be a file URL, for example, file:///var/lib/dcos/cosmos/staged-packages."
+}
+
+variable "dcos_package_storage_uri" {
+ default = ""
+ description = "This parameter specifies where to permanently store DC/OS packages. The value must be a file URL, for example, file:///var/lib/dcos/cosmos/packages."
+}
+
 
 # Example value on how to configure rexray below
 # default = "{\"rexray\": {\"modules\": {\"default-docker\": {\"disabled\": true}, \"default-admin\": {\"host\": \"tcp://127.0.0.1:61003\"}}, \"loglevel\": \"info\"}}"


### PR DESCRIPTION
Section: Pull down the DC/OS terraform scripts below

There is a module called dcos-tested-aws-oses that contains all the tested scripts per operating system. The deployment strategy is a base AMI coupled with a prereq script.sh to get it ready to install dcos-core components. Its simple to add other operating systems by adding the ami, region, and install scripts to meet the dcos specifications that can be found **here** and **here** as an example.

https://github.com/bernadinm/terraform-dcos/blob/master/aws/README.md#install-terraform

here
`https://dcos.io/docs/1.9/administration/installing/custom/system-requirements/`
is now https://dcos.io/docs/1.9/installing/custom/system-requirements/


here
`https://dcos.io/docs/1.9/administration/installing/custom/system-requirements/install-docker-centos/`
is now https://dcos.io/docs/1.9/installing/custom/system-requirements/install-docker-centos/