### PR TITLE
Rhel support

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -350,7 +350,7 @@ terraform destroy
   - [X] Support for specific versions of CoreOS
   - [X] Support for Centos
   - [X] Secondary support for specific versions of Centos
-  - [ ] Support for RHEL
+  - [X] Support for RHEL
   - [ ] Secondary support for specific versions of RHEL
   - [ ] Multi AZ Support
 

--- a/aws/modules/dcos-tested-aws-oses/platform/cloud/aws/centos_7.3/setup.sh
+++ b/aws/modules/dcos-tested-aws-oses/platform/cloud/aws/centos_7.3/setup.sh
@@ -1,0 +1,32 @@
+sudo setenforce 0 && \
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+# sudo yum -y update --exclude="docker-engine*"
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon --storage-driver=overlay
+EOF
+sudo yum install -y docker-engine-1.13.1
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo yum install -y wget
+sudo yum install -y git
+sudo yum install -y unzip
+sudo yum install -y curl
+sudo yum install -y xz
+sudo yum install -y ipset
+sudo yum install -y ntp
+sudo systemctl enable ntpd
+sudo systemctl start ntpd
+sudo getent group nogroup || sudo groupadd nogroup
+sudo getent group docker || sudo groupadd docker
+sudo touch /opt/dcos-prereqs.installed

--- a/aws/modules/dcos-tested-aws-oses/platform/cloud/aws/rhel_7.3/setup.sh
+++ b/aws/modules/dcos-tested-aws-oses/platform/cloud/aws/rhel_7.3/setup.sh
@@ -1,0 +1,32 @@
+sudo setenforce 0 && \
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+# sudo yum -y update --exclude="docker-engine*"
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon --storage-driver=overlay
+EOF
+sudo yum install -y docker-engine-1.13.1
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo yum install -y wget
+sudo yum install -y git
+sudo yum install -y unzip
+sudo yum install -y curl
+sudo yum install -y xz
+sudo yum install -y ipset
+sudo yum install -y ntp
+sudo systemctl enable ntpd
+sudo systemctl start ntpd
+sudo getent group nogroup || sudo groupadd nogroup
+sudo getent group docker || sudo groupadd docker
+sudo touch /opt/dcos-prereqs.installed

--- a/aws/modules/dcos-tested-aws-oses/variables.tf
+++ b/aws/modules/dcos-tested-aws-oses/variables.tf
@@ -12,8 +12,10 @@ variable "aws_ami" {
  type = "map"
  default = {
  centos_7.2_us-west-2      = "ami-d2c924b2"
+ centos_7.3_us-west-2      = "ami-f4533694"
  coreos_835.13.0_us-west-2 = "ami-4f00e32f"
  coreos_1235.9.0_us-west-2 = "ami-4c49f22c"
+ rhel_7.3_us-west-2        = "ami-b55a51cc"
  }
 }
 


### PR DESCRIPTION
Installed an upgraded DC/OS with RHEL 7.3. You can now call use this OS by specifying `os=rhel_7.3` for your entire cluster. 