### PR TITLE
Added CoreOS AMIs for eu-west-1 region

### DIFF
--- a/aws/modules/dcos-tested-aws-oses/variables.tf
+++ b/aws/modules/dcos-tested-aws-oses/variables.tf
@@ -11,6 +11,9 @@ variable "aws_default_os_user" {
 variable "aws_ami" {
  type = "map"
  default = {
+ coreos_835.13.0_eu-west-1 = "ami-4b18aa38"
+ coreos_1235.9.0_eu-west-1 = "ami-188dd67e"
+ coreos_1465.8.0_eu-west-1 = "ami-1a589463"
  centos_7.2_us-west-2      = "ami-d2c924b2"
  centos_7.3_us-west-2      = "ami-f4533694"
  coreos_835.13.0_us-west-2 = "ami-4f00e32f"


### PR DESCRIPTION
Prior to this change the only AMIs listed by default were the ones
in us-west-2. But there are users of DC/OS outside of that region
hence this commit.

I've only used coreos_1235.9.0_eu-west-1 = "ami-188dd67e", the
rest I've added based on their name.